### PR TITLE
Added parameters to URL domains for Ruuter yml files

### DIFF
--- a/DSL/Ruuter/GET/metrics/intents.yml
+++ b/DSL/Ruuter/GET/metrics/intents.yml
@@ -17,7 +17,7 @@ check_for_request_data:
 get_intents:
   call: http.post
   args:
-    url: http://resql:8082/get-intents
+    url: "[#ANALYTICS_RESQL]/get-intents"
   result: results
 
 return_value:

--- a/DSL/Ruuter/GET/negative-feedback.yml
+++ b/DSL/Ruuter/GET/negative-feedback.yml
@@ -14,7 +14,7 @@ extract_request_data:
 extract_cookie_data:
   call: http.post
   args:
-    url: http://ruuter:8080/mocks/mock-custom-jwt-userinfo # todo: replace with real TIM url
+    url: "[#ANALYTICS_PUBLIC_RUUTER]/mocks/mock-custom-jwt-userinfo" # todo: replace with real TIM url
     headers:
       cookie: ${cookie}
     body:
@@ -30,7 +30,7 @@ validate_role:
 get_negative_feedback:
   call: http.post
   args:
-    url: http://resql:8082/negative-feedback
+    url: "[#ANALYTICS_RESQL]/negative-feedback"
     body:
       start: ${start}
       end: ${end}

--- a/DSL/Ruuter/GET/odp/dataset.yml
+++ b/DSL/Ruuter/GET/odp/dataset.yml
@@ -1,19 +1,19 @@
 getKey:
   call: http.post
   args:
-    url: http://resql:8082/get-odp-settings
+    url: "[#ANALYTICS_RESQL]/get-odp-settings"
   result: settings
   
 authenticate:
   call: http.post
   args:
-    url: http://open_data_service:8888/api/auth/key-login
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/auth/key-login"
     headers:
       X-API-KEY: ${settings.response.body[0].odpKey}
   result: apiToken
 
 
-  #url: http://open_data_service:8888/api/organizations/my-organization/${settings.response.body[0].orgId}/datasets/${incoming.params.datasetId}
+  #url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/organizations/my-organization/${settings.response.body[0].orgId}/datasets/${incoming.params.datasetId}"
 get_dataset_metadata:
   call: reflect.mock
   args:

--- a/DSL/Ruuter/GET/odp/scheduled-reports.yml
+++ b/DSL/Ruuter/GET/odp/scheduled-reports.yml
@@ -1,7 +1,7 @@
 getScheduledReports:
   call: http.post
   args:
-    url: http://resql:8082/get-scheduled-reports
+    url: "[#ANALYTICS_RESQL]/get-scheduled-reports"
   result: scheduledReports
 
 return:

--- a/DSL/Ruuter/GET/odp/settings.yml
+++ b/DSL/Ruuter/GET/odp/settings.yml
@@ -1,7 +1,7 @@
 checkOdpKey:
   call: http.post
   args:
-    url: http://resql:8082/get-odp-settings
+    url: "[#ANALYTICS_RESQL]/get-odp-settings"
   result: odpsettings
 
 return:

--- a/DSL/Ruuter/GET/odp/values.yml
+++ b/DSL/Ruuter/GET/odp/values.yml
@@ -5,7 +5,7 @@ assign_vars:
 get_keywords:
   call: http.get
   args:
-    url: http://open_data_service:8888/api/keywords
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/keywords"
     query:
       lang: ${lang}
   result: keywordsResult
@@ -13,7 +13,7 @@ get_keywords:
 get_categories:
   call: http.get
   args:
-    url: http://open_data_service:8888/api/categories
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/categories"
     query:
       lang: ${lang}
   result: categoriesResult
@@ -21,7 +21,7 @@ get_categories:
 get_regions:
   call: http.get
   args:
-    url: http://open_data_service:8888/api/regions
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/regions"
     query:
       lang: ${lang}
   result: regionsResult
@@ -29,7 +29,7 @@ get_regions:
 get_licences:
   call: http.get
   args:
-    url: http://open_data_service:8888/api/licences
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/licences"
     query:
       lang: ${lang}
   result: licencesResult

--- a/DSL/Ruuter/GET/overview/metrics.yml
+++ b/DSL/Ruuter/GET/overview/metrics.yml
@@ -31,7 +31,7 @@ checkMetric:
 getTotalChatsDayResults:
   call: http.post
   args:
-    url: http://resql:8082/overview-total-chats
+    url: "[#ANALYTICS_RESQL]/overview-total-chats"
     body:
       group_period: 'day'
   result: results
@@ -40,7 +40,7 @@ getTotalChatsDayResults:
 getTotalChatsMonthResults:
   call: http.post
   args:
-    url: http://resql:8082/overview-total-chats
+    url: "[#ANALYTICS_RESQL]/overview-total-chats"
     body:
       group_period: 'month'
   result: results
@@ -49,7 +49,7 @@ getTotalChatsMonthResults:
 getTotalChatsNoCSAResults:
   call: http.post
   args:
-    url: http://resql:8082/overview-total-chats-no-csa
+    url: "[#ANALYTICS_RESQL]/overview-total-chats-no-csa"
     body:
       group_period: 'day'
   result: results
@@ -58,7 +58,7 @@ getTotalChatsNoCSAResults:
 getAvgChatsMonthResults:
   call: http.post
   args:
-    url: http://resql:8082/overview-avg-chats
+    url: "[#ANALYTICS_RESQL]/overview-avg-chats"
     body:
       group_period: 'month'
   result: results
@@ -67,7 +67,7 @@ getAvgChatsMonthResults:
 getAvgChatsWeekResults:
   call: http.post
   args:
-    url: http://resql:8082/overview-avg-chats
+    url: "[#ANALYTICS_RESQL]/overview-avg-chats"
     body:
       group_period: 'week'
   result: results
@@ -76,7 +76,7 @@ getAvgChatsWeekResults:
 getAvgChatsNoCSAMonthResult:
   call: http.post
   args:
-    url: http://resql:8082/overview-avg-chats-no-csa
+    url: "[#ANALYTICS_RESQL]/overview-avg-chats-no-csa"
     body:
       group_period: 'month'
   result: results
@@ -85,7 +85,7 @@ getAvgChatsNoCSAMonthResult:
 getAvgChatsNoCSAWeekResult:
   call: http.post
   args:
-    url: http://resql:8082/overview-avg-chats-no-csa
+    url: "[#ANALYTICS_RESQL]/overview-avg-chats-no-csa"
     body:
       group_period: 'week'
   result: results
@@ -94,7 +94,7 @@ getAvgChatsNoCSAWeekResult:
 getAvgWaitingTimeDayResult:
   call: http.post
   args:
-    url: http://resql:8082/overview-avg-waiting-time
+    url: "[#ANALYTICS_RESQL]/overview-avg-waiting-time"
     body:
       group_period: 'day'
   result: results
@@ -103,7 +103,7 @@ getAvgWaitingTimeDayResult:
 getAvgWaitingTimeWeekResult:
   call: http.post
   args:
-    url: http://resql:8082/overview-avg-waiting-time
+    url: "[#ANALYTICS_RESQL]/overview-avg-waiting-time"
     body:
       group_period: 'week'
   result: results
@@ -112,14 +112,14 @@ getAvgWaitingTimeWeekResult:
 getTotalForwardedChatsResult:
   call: http.post
   args:
-    url: http://resql:8082/overview-total-forwarded-chats
+    url: "[#ANALYTICS_RESQL]/overview-total-forwarded-chats"
   result: results
   next: respond
 
 getChatActivityResult:
   call: http.post
   args:
-    url: http://resql:8082/overview-chat-activity-chart
+    url: "[#ANALYTICS_RESQL]/overview-chat-activity-chart"
   result: results
   next: respond
 

--- a/DSL/Ruuter/GET/overview/preferences.yml
+++ b/DSL/Ruuter/GET/overview/preferences.yml
@@ -11,7 +11,7 @@ extract_request_data:
 extract_token_data:
   call: http.post
   args:
-    url: http://ruuter:8080/mocks/mock-custom-jwt-userinfo # todo: replace with real TIM url
+    url: "[#ANALYTICS_PUBLIC_RUUTER]/mocks/mock-custom-jwt-userinfo" # todo: replace with real TIM url
     headers:
       cookie: ${cookie}
     body:
@@ -27,7 +27,7 @@ validate_role:
 get_metrics_preferences:
   call: http.post
   args:
-    url: http://resql:8082/overview-metric-preferences
+    url: "[#ANALYTICS_RESQL]/overview-metric-preferences"
     body:
       user_id_code: ${jwtResult.response.body.response.idCode}
   result: metrics

--- a/DSL/Ruuter/GET/testing.yml
+++ b/DSL/Ruuter/GET/testing.yml
@@ -1,7 +1,7 @@
 get_message:
   call: http.post
   args:
-    url: http://resql:8082/testing
+    url: "[#ANALYTICS_RESQL]/testing"
   result: the_message
 
 return_value:

--- a/DSL/Ruuter/POST/buerokratt/byk-avg-response-speed.yml
+++ b/DSL/Ruuter/POST/buerokratt/byk-avg-response-speed.yml
@@ -23,7 +23,7 @@ missing_parameter:
 avg_response_time:
   call: http.post
   args:
-    url: http://resql:8082/byk-avg-response-speed
+    url: "[#ANALYTICS_RESQL]/byk-avg-response-speed"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/buerokratt/byk-avg-sessions-time.yml
+++ b/DSL/Ruuter/POST/buerokratt/byk-avg-sessions-time.yml
@@ -34,7 +34,7 @@ empty_byk:
 byk:
   call: http.post
   args:
-    url: http://resql:8082/byk-avg-sessions-time-chatbot
+    url: "[#ANALYTICS_RESQL]/byk-avg-sessions-time-chatbot"
     body:
       period: ${period}
       start: ${start}
@@ -58,7 +58,7 @@ empty_csa:
 csa:
   call: http.post
   args:
-    url: http://resql:8082/byk-avg-sessions-time-csa
+    url: "[#ANALYTICS_RESQL]/byk-avg-sessions-time-csa"
     body:
       period: ${period}
       start: ${start}
@@ -82,7 +82,7 @@ empty_customer:
 customer:
   call: http.post
   args:
-    url: http://resql:8082/byk-avg-sessions-time-customer
+    url: "[#ANALYTICS_RESQL]/byk-avg-sessions-time-customer"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/buerokratt/byk-intents.yml
+++ b/DSL/Ruuter/POST/buerokratt/byk-intents.yml
@@ -34,7 +34,7 @@ empty_option1:
 fetch_option1:
   call: http.post
   args:
-    url: http://resql:8082/byk-intents-count
+    url: "[#ANALYTICS_RESQL]/byk-intents-count"
     body:
       period: ${period}
       start: ${start}
@@ -58,7 +58,7 @@ empty_option2:
 fetch_option2:
   call: http.post
   args:
-    url: http://resql:8082/byk-new-intents
+    url: "[#ANALYTICS_RESQL]/byk-new-intents"
     body:
       period: ${period}
       start: ${start}
@@ -82,7 +82,7 @@ empty_option3:
 fetch_option3:
   call: http.post
   args:
-    url: http://resql:8082/byk-modified-intents
+    url: "[#ANALYTICS_RESQL]/byk-modified-intents"
     body:
       period: ${period}
       start: ${start}
@@ -106,7 +106,7 @@ empty_option4:
 fetch_option4:
   call: http.post
   args:
-    url: http://resql:8082/byk-avg-intents
+    url: "[#ANALYTICS_RESQL]/byk-avg-intents"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/buerokratt/byk-pct-correctly-understood.yml
+++ b/DSL/Ruuter/POST/buerokratt/byk-pct-correctly-understood.yml
@@ -23,7 +23,7 @@ missing_parameter:
 byk-pct-correctly-understood:
   call: http.post
   args:
-    url: http://resql:8082/byk-pct-correctly-understood
+    url: "[#ANALYTICS_RESQL]/byk-pct-correctly-understood"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/chat/status.yml
+++ b/DSL/Ruuter/POST/chat/status.yml
@@ -24,7 +24,7 @@ check_for_csa_events:
 call_all_chats:
   call: http.post
   args:
-    url: http://resql:8082/status-all-chats
+    url: "[#ANALYTICS_RESQL]/status-all-chats"
     body:
       events: ${incoming.body.events}
       metric: ${incoming.body.metric}
@@ -36,7 +36,7 @@ call_all_chats:
 call_csa_chats:
   call: http.post
   args:
-    url: http://resql:8082/status-csa-chats
+    url: "[#ANALYTICS_RESQL]/status-csa-chats"
     body:
       events: ${incoming.body.csa_events}
       metric: ${incoming.body.metric}

--- a/DSL/Ruuter/POST/chats/avg-median-waiting-time.yml
+++ b/DSL/Ruuter/POST/chats/avg-median-waiting-time.yml
@@ -34,7 +34,7 @@ empty_avg:
 avg:
   call: http.post
   args:
-    url: http://resql:8082/chat-avg-waiting-time
+    url: "[#ANALYTICS_RESQL]/chat-avg-waiting-time"
     body:
       period: ${period}
       start: ${start}
@@ -58,7 +58,7 @@ empty_median:
 median:
   call: http.post
   args:
-    url: http://resql:8082/chat-median-waiting-time
+    url: "[#ANALYTICS_RESQL]/chat-median-waiting-time"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/chats/chat-avg-duration.yml
+++ b/DSL/Ruuter/POST/chats/chat-avg-duration.yml
@@ -23,7 +23,7 @@ missing_parameter:
 fetch:
   call: http.post
   args:
-    url: http://resql:8082/chat-avg-duration
+    url: "[#ANALYTICS_RESQL]/chat-avg-duration"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/chats/chat-avg-num-of-messages.yml
+++ b/DSL/Ruuter/POST/chats/chat-avg-num-of-messages.yml
@@ -23,7 +23,7 @@ missing_parameter:
 fetch:
   call: http.post
   args:
-    url: http://resql:8082/chat-avg-num-of-messages
+    url: "[#ANALYTICS_RESQL]/chat-avg-num-of-messages"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/chats/chat-idle-count.yml
+++ b/DSL/Ruuter/POST/chats/chat-idle-count.yml
@@ -23,7 +23,7 @@ missing_parameter:
 fetch:
   call: http.post
   args:
-    url: http://resql:8082/chat-idle-count
+    url: "[#ANALYTICS_RESQL]/chat-idle-count"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/chats/chat-total-count.yml
+++ b/DSL/Ruuter/POST/chats/chat-total-count.yml
@@ -34,7 +34,7 @@ empty_byk:
 byk:
   call: http.post
   args:
-    url: http://resql:8082/chat-count-only-chatbot
+    url: "[#ANALYTICS_RESQL]/chat-count-only-chatbot"
     body:
       period: ${period}
       start: ${start}
@@ -58,7 +58,7 @@ empty_csa:
 csa:
   call: http.post
   args:
-    url: http://resql:8082/chat-count-with-csa
+    url: "[#ANALYTICS_RESQL]/chat-count-with-csa"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/chats/contact-information-fulfilled.yml
+++ b/DSL/Ruuter/POST/chats/contact-information-fulfilled.yml
@@ -34,7 +34,7 @@ empty_outside_working_hours:
 outside_working_hours:
   call: http.post
   args:
-    url: http://resql:8082/chat-cif-outside-working-hours
+    url: "[#ANALYTICS_RESQL]/chat-cif-outside-working-hours"
     body:
       period: ${period}
       start: ${start}
@@ -58,7 +58,7 @@ empty_long_waiting_time:
 long_waiting_time:
   call: http.post
   args:
-    url: http://resql:8082/chat-cif-long-waiting-time
+    url: "[#ANALYTICS_RESQL]/chat-cif-long-waiting-time"
     body:
       period: ${period}
       start: ${start}
@@ -83,7 +83,7 @@ empty_all_csas_away:
 all_csas_away:
   call: http.post
   args:
-    url: http://resql:8082/chat-cif-all-csas-away
+    url: "[#ANALYTICS_RESQL]/chat-cif-all-csas-away"
     body:
       period: ${period}
       start: ${start}

--- a/DSL/Ruuter/POST/csa/avg-chat-time.yml
+++ b/DSL/Ruuter/POST/csa/avg-chat-time.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 post_step:
   call: http.post
   args:
-    url: http://resql:8082/csa-avg-chat-time
+    url: "[#ANALYTICS_RESQL]/csa-avg-chat-time"
     body:
       metric: ${incoming.body.metric}
       start: ${incoming.body.start_date}

--- a/DSL/Ruuter/POST/csa/avg-present-number.yml
+++ b/DSL/Ruuter/POST/csa/avg-present-number.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 post_step:
   call: http.post
   args:
-    url: http://resql:8082/csa-avg-present-number
+    url: "[#ANALYTICS_RESQL]/csa-avg-present-number"
     body:
       metric: ${incoming.body.metric}
       start: ${incoming.body.start_date}

--- a/DSL/Ruuter/POST/csa/avg-time-picking-up-chat.yml
+++ b/DSL/Ruuter/POST/csa/avg-time-picking-up-chat.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 post_step:
   call: http.post
   args:
-    url: http://resql:8082/csa-avg-time-picking-up-chats
+    url: "[#ANALYTICS_RESQL]/csa-avg-time-picking-up-chats"
     body:
       metric: ${incoming.body.metric}
       start: ${incoming.body.start_date}

--- a/DSL/Ruuter/POST/csa/chat_forwards.yml
+++ b/DSL/Ruuter/POST/csa/chat_forwards.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 post_step:
   call: http.post
   args:
-    url: http://resql:8082/csa-chat-forwards
+    url: "[#ANALYTICS_RESQL]/csa-chat-forwards"
     body:
       metric: ${incoming.body.metric}
       start: ${incoming.body.start_date}

--- a/DSL/Ruuter/POST/csa/total-chats.yml
+++ b/DSL/Ruuter/POST/csa/total-chats.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 post_step:
   call: http.post
   args:
-    url: http://resql:8082/csa-chats-count
+    url: "[#ANALYTICS_RESQL]/csa-chats-count"
     body:
       metric: ${incoming.body.metric}
       start: ${incoming.body.start_date}

--- a/DSL/Ruuter/POST/csv.yml
+++ b/DSL/Ruuter/POST/csv.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 get_csv:
   call: http.post
   args:
-    url: http://data_mapper:3000/hbs/analytics/get-csv
+    url: "[#ANALYTICS_DMAPPER]/hbs/analytics/get-csv"
     headers:
       type: 'csv'
     body:

--- a/DSL/Ruuter/POST/feedback/avg-feedback-to-buerokratt-chats.yml
+++ b/DSL/Ruuter/POST/feedback/avg-feedback-to-buerokratt-chats.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 post_step:
   call: http.post
   args:
-    url: http://resql:8082/feedback-avg-feedback-to-buerokratt-chats
+    url: "[#ANALYTICS_RESQL]/feedback-avg-feedback-to-buerokratt-chats"
     body:
       metric: ${incoming.body.metric}
       start: ${incoming.body.start_date}

--- a/DSL/Ruuter/POST/feedback/chats-with-negative-feedback.yml
+++ b/DSL/Ruuter/POST/feedback/chats-with-negative-feedback.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 post_step:
   call: http.post
   args:
-    url: http://resql:8082/feedback-chats-with-negative-feedback
+    url: "[#ANALYTICS_RESQL]/feedback-chats-with-negative-feedback"
     body:
       events: ${incoming.body.events}
       start: ${incoming.body.start_date}

--- a/DSL/Ruuter/POST/feedback/csa-chats-feedback-nps.yml
+++ b/DSL/Ruuter/POST/feedback/csa-chats-feedback-nps.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 post_step:
   call: http.post
   args:
-    url: http://resql:8082/feedback-csa-chats-feedback-nps
+    url: "[#ANALYTICS_RESQL]/feedback-csa-chats-feedback-nps"
     body:
       metric: ${incoming.body.metric}
       start: ${incoming.body.start_date}

--- a/DSL/Ruuter/POST/feedback/selected-csa-feedback-nps.yml
+++ b/DSL/Ruuter/POST/feedback/selected-csa-feedback-nps.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 post_step:
   call: http.post
   args:
-    url: http://resql:8082/feedback-selected-csa-feedback-nps
+    url: "[#ANALYTICS_RESQL]/feedback-selected-csa-feedback-nps"
     body:
       metric: ${incoming.body.metric}
       start: ${incoming.body.start_date}

--- a/DSL/Ruuter/POST/metrics/intents.yml
+++ b/DSL/Ruuter/POST/metrics/intents.yml
@@ -17,7 +17,7 @@ check_for_request_data:
 get_intent:
   call: http.post
   args:
-    url: http://resql:8082/get-intent
+    url: "[#ANALYTICS_RESQL]/get-intent"
   body:
     intent: ${intent}
     start: ${start}

--- a/DSL/Ruuter/POST/odp/dataset.yml
+++ b/DSL/Ruuter/POST/odp/dataset.yml
@@ -1,13 +1,13 @@
 getKey:
   call: http.post
   args:
-    url: http://resql:8082/get-odp-settings
+    url: "[#ANALYTICS_RESQL]/get-odp-settings"
   result: settings
   
 authenticate:
   call: http.post
   args:
-    url: http://open_data_service:8888/api/auth/key-login
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/auth/key-login"
     headers:
       X-API-KEY: ${settings.response.body[0].odpKey}
   result: apiToken
@@ -15,7 +15,7 @@ authenticate:
 createDataset:
   call: http.post
   args:
-    url: http://open_data_service:8888/api/users/me/datasets # replace with organization url that contains org id
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/users/me/datasets" # replace with organization url that contains org id
     body:
       nameEt: ${incoming.body.nameEt}
       nameEn: ${incoming.body.nameEn}
@@ -53,7 +53,7 @@ setUpSchedule:
 saveJobInformation:
   call: http.post
   args:
-    url: http://resql:8082/add-scheduled-report
+    url: "[#ANALYTICS_RESQL]/add-scheduled-report"
     body:
       name: ${incoming.body.nameEt}
       period: ${incoming.body.updateIntervalUnit}

--- a/DSL/Ruuter/POST/odp/delete-scheduled-report.yml
+++ b/DSL/Ruuter/POST/odp/delete-scheduled-report.yml
@@ -1,7 +1,7 @@
 getJobDetails:
   call: http.post
   args:
-    url: http://resql:8082/get-scheduled-report
+    url: "[#ANALYTICS_RESQL]/get-scheduled-report"
     body:
       datasetId: ${incoming.body.datasetId}
   result: jobDetails
@@ -18,7 +18,7 @@ removeSchedule:
 deleteScheduledReport:
   call: http.post
   args:
-    url: http://resql:8082/delete-scheduled-report
+    url: "[#ANALYTICS_RESQL]/delete-scheduled-report"
     body:
       id: ${jobDetails.response.body[0].id}
   result: delete

--- a/DSL/Ruuter/POST/odp/delete-settings.yml
+++ b/DSL/Ruuter/POST/odp/delete-settings.yml
@@ -1,7 +1,7 @@
 deleteOdpKey:
   call: http.post
   args:
-    url: http://resql:8082/delete-odp-settings
+    url: "[#ANALYTICS_RESQL]/delete-odp-settings"
   result: delete
 
 return:

--- a/DSL/Ruuter/POST/odp/metrics.yml
+++ b/DSL/Ruuter/POST/odp/metrics.yml
@@ -5,7 +5,7 @@ set_variables:
 get-timescale:
   call: http.post
   args:
-    url: http://resql:8082/get-period-times
+    url: "[#ANALYTICS_RESQL]/get-period-times"
     body:
       start: ${incoming.body.start}
       end: ${incoming.body.end}
@@ -25,7 +25,7 @@ empty-get-chat-count-total:
 get-chat-count-total:
   call: http.post
   args:
-    url: http://resql:8082/get-chat-count-total
+    url: "[#ANALYTICS_RESQL]/get-chat-count-total"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -44,7 +44,7 @@ empty-get-chat-count-no-csa:
 get-chat-count-no-csa:
   call: http.post
   args:
-    url: http://resql:8082/get-chat-count-no-csa
+    url: "[#ANALYTICS_RESQL]/get-chat-count-no-csa"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -63,7 +63,7 @@ empty-get-avg-waiting-time:
 get-avg-waiting-time:
   call: http.post
   args:
-    url: http://resql:8082/get-avg-waiting-time
+    url: "[#ANALYTICS_RESQL]/get-avg-waiting-time"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -82,7 +82,7 @@ empty-get-avg-messages:
 get-avg-messages:
   call: http.post
   args:
-    url: http://resql:8082/get-avg-messages
+    url: "[#ANALYTICS_RESQL]/get-avg-messages"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -101,7 +101,7 @@ empty-get-avg-time:
 get-avg-time:
   call: http.post
   args:
-    url: http://resql:8082/get-avg-time
+    url: "[#ANALYTICS_RESQL]/get-avg-time"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -120,7 +120,7 @@ empty-get-avg-time-no-csa:
 get-avg-time-no-csa:
   call: http.post
   args:
-    url: http://resql:8082/get-avg-time-no-csa
+    url: "[#ANALYTICS_RESQL]/get-avg-time-no-csa"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -139,7 +139,7 @@ empty-get-avg-time-csa:
 get-avg-time-csa:
   call: http.post
   args:
-    url: http://resql:8082/get-avg-time-csa
+    url: "[#ANALYTICS_RESQL]/get-avg-time-csa"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -158,7 +158,7 @@ empty-get-avg-session-length-client-left:
 get-avg-session-length-client-left:
   call: http.post
   args:
-    url: http://resql:8082/get-avg-session-length-client-left
+    url: "[#ANALYTICS_RESQL]/get-avg-session-length-client-left"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -177,7 +177,7 @@ empty-get-avg-session-length-csa:
 get-avg-session-length-csa:
   call: http.post
   args:
-    url: http://resql:8082/get-avg-session-length-csa
+    url: "[#ANALYTICS_RESQL]/get-avg-session-length-csa"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -196,7 +196,7 @@ empty-get-avg-session-length-no-csa:
 get-avg-session-length-no-csa:
   call: http.post
   args:
-    url: http://resql:8082/get-avg-session-length-no-csa
+    url: "[#ANALYTICS_RESQL]/get-avg-session-length-no-csa"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -215,7 +215,7 @@ empty-get-avg-response-time:
 get-avg-response-time:
   call: http.post
   args:
-    url: http://resql:8082/get-avg-response-time
+    url: "[#ANALYTICS_RESQL]/get-avg-response-time"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -234,7 +234,7 @@ empty-get-pct-correctly-understood:
 get-pct-correctly-understood:
   call: http.post
   args:
-    url: http://resql:8082/get-pct-correctly-understood
+    url: "[#ANALYTICS_RESQL]/get-pct-correctly-understood"
     body:
       start: ${times.response.body[0].start}
       end: ${times.response.body[0].end}
@@ -248,7 +248,7 @@ gather_responses:
 convert_data:
   call: http.post
   args:
-    url: http://data_mapper:3000/hbs/analytics/array-to-object
+    url: "[#ANALYTICS_DMAPPER]/hbs/analytics/array-to-object"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/POST/odp/settings.yml
+++ b/DSL/Ruuter/POST/odp/settings.yml
@@ -7,13 +7,13 @@ assign:
 deleteOdpKey:
   call: http.post
   args:
-    url: http://resql:8082/delete-odp-settings
+    url: "[#ANALYTICS_RESQL]/delete-odp-settings"
   result: delete
 
 saveOdpKey:
   call: http.post
   args:
-    url: http://resql:8082/set-odp-settings
+    url: "[#ANALYTICS_RESQL]/set-odp-settings"
     body:
       keyId: ${keyId}
       apiKey: ${apiKey}
@@ -23,13 +23,13 @@ saveOdpKey:
 getKey:
   call: http.post
   args:
-    url: http://resql:8082/get-odp-settings
+    url: "[#ANALYTICS_RESQL]/get-odp-settings"
   result: settings
   
 verify:
   call: http.post
   args:
-    url: http://open_data_service:8888/api/auth/key-login
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/auth/key-login"
     headers:
       X-API-KEY: ${settings.response.body[0].odpKey}
   result: apiToken
@@ -42,7 +42,7 @@ check_response:
 cleanupInvalidKey:
   call: http.post
   args:
-    url: http://resql:8082/delete-odp-settings
+    url: "[#ANALYTICS_RESQL]/delete-odp-settings"
   result: delete
   next: return_error
 

--- a/DSL/Ruuter/POST/odp/task-runner.yml
+++ b/DSL/Ruuter/POST/odp/task-runner.yml
@@ -1,7 +1,7 @@
 getJobDetails:
   call: http.post
   args:
-    url: http://resql:8082/get-scheduled-report
+    url: "[#ANALYTICS_RESQL]/get-scheduled-report"
     body:
       datasetId: ${incoming.params.datasetId}
   result: jobDetails

--- a/DSL/Ruuter/POST/odp/update-scheduled-report.yml
+++ b/DSL/Ruuter/POST/odp/update-scheduled-report.yml
@@ -1,13 +1,13 @@
 getKey:
   call: http.post
   args:
-    url: http://resql:8082/get-odp-settings
+    url: "[#ANALYTICS_RESQL]/get-odp-settings"
   result: settings
   
 authenticate:
   call: http.post
   args:
-    url: http://open_data_service:8888/api/auth/key-login
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/auth/key-login"
     headers:
       X-API-KEY: ${settings.response.body[0].odpKey}
   result: apiToken
@@ -18,7 +18,7 @@ updateDataset:
   requestType: post
   args:
     request:
-      #url: http://open_data_service:8888/api/users/organizations/my-organizations/${settings.response.body[0].orgId}/datasets/${incoming.body.datasetId}
+      #url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/users/organizations/my-organizations/${settings.response.body[0].orgId}/datasets/${incoming.body.datasetId}"
       body:
         nameEt: ${incoming.body.nameEt}
         nameEn: ${incoming.body.nameEn}
@@ -41,7 +41,7 @@ updateDataset:
 getJobDetails:
   call: http.post
   args:
-    url: http://resql:8082/get-scheduled-report
+    url: "[#ANALYTICS_RESQL]/get-scheduled-report"
     body:
       datasetId: ${incoming.body.datasetId}
   result: jobDetails
@@ -66,7 +66,7 @@ setUpSchedule:
 saveJobInformation:
   call: http.post
   args:
-    url: http://resql:8082/add-scheduled-report
+    url: "[#ANALYTICS_RESQL]/add-scheduled-report"
     body:
       name: ${incoming.body.nameEt}
       period: ${incoming.body.updateIntervalUnit}

--- a/DSL/Ruuter/POST/odp/upload.yml
+++ b/DSL/Ruuter/POST/odp/upload.yml
@@ -1,13 +1,13 @@
 getKey:
   call: http.post
   args:
-    url: http://resql:8082/get-odp-settings
+    url: "[#ANALYTICS_RESQL]/get-odp-settings"
   result: settings
   
 authenticate:
   call: http.post
   args:
-    url: http://open_data_service:8888/api/auth/key-login
+    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/auth/key-login"
     headers:
       X-API-KEY: ${settings.response.body[0].odpKey}
   result: apiToken
@@ -28,7 +28,7 @@ return:
 #upload:
 #  call: http.post
 #  args:
-#    url: http://open_data_service:8888/api/organizations/my-organizations/${settings.response.body[0].orgId}/datasets/${incoming.body.datasetId}/upload
+#    url: "[#ANALYTICS_OPEN_DATA_SERVICE]/api/organizations/my-organizations/${settings.response.body[0].orgId}/datasets/${incoming.body.datasetId}/upload"
 #    file:
 #      name: "metrics.csv"
 #        content: ${metricDataCSV}

--- a/DSL/Ruuter/POST/overview/preferences.yml
+++ b/DSL/Ruuter/POST/overview/preferences.yml
@@ -20,7 +20,7 @@ extract_request_data:
 extract_token_data:
   call: http.post
   args:
-    url: http://ruuter:8080/mocks/mock-custom-jwt-userinfo # todo: replace with real TIM url
+    url: "[#ANALYTICS_PUBLIC_RUUTER]/mocks/mock-custom-jwt-userinfo" # todo: replace with real TIM url
     headers:
       cookie: ${cookie}
     body:
@@ -36,7 +36,7 @@ validate_role:
 update_metrics_preferences:
   call: http.post
   args:
-    url: http://resql:8082/update-overview-metric-preferences
+    url: "[#ANALYTICS_RESQL]/update-overview-metric-preferences"
     body:
       user_id_code: ${jwtResult.response.body.response.idCode}
       active: ${active}
@@ -47,7 +47,7 @@ update_metrics_preferences:
 get_metrics_preferences:
   call: http.post
   args:
-    url: http://resql:8082/overview-metric-preferences
+    url: "[#ANALYTICS_RESQL]/overview-metric-preferences"
     body:
       user_id_code: ${jwtResult.response.body.response.idCode}
   result: metrics


### PR DESCRIPTION
Changed a total of 40 files, by replacing the http and domain part of the url with an parameter. For example [#ANALYTICS_RESQL]. Also added "" for the URL.

Similar issue to https://github.com/buerokratt/Service-Module/issues/128
Parameters:
http://resql:8082 -> [#ANALYTICS_RESQL]
http://ruuter:8080 -> [#ANALYTICS_PUBLIC_RUUTER]
http://open_data_service:8888 -> [#ANALYTICS_OPEN_DATA_SERVICE]