### PR TITLE
feat: Fix avg feedback query to get bureokratt messages instead of chatbot

### DIFF
--- a/DSL/Resql/feedback-avg-feedback-to-buerokratt-chats.sql
+++ b/DSL/Resql/feedback-avg-feedback-to-buerokratt-chats.sql
@@ -5,7 +5,7 @@ WHERE EXISTS
     (SELECT 1
      FROM message
      WHERE message.chat_base_id = chat.base_id
-       AND message.author_role = 'chatbot')
+       AND message.author_role = 'buerokratt')
 AND status = 'ENDED'
 AND created::date BETWEEN :start::date AND :end::date
 GROUP BY date_time


### PR DESCRIPTION
Fix analytics module avg feedback sql query to get 'buerokratt' author-role messages instead of 'chatbot' author-role messages #291 