### PR TITLE
Hid the button for the "Kontakti jätmised" in the analytics/chats page.

### DIFF
--- a/GUI/src/pages/ChatsPage/data.tsx
+++ b/GUI/src/pages/ChatsPage/data.tsx
@@ -1,7 +1,7 @@
 import {
   getAvgChatWaitingTime,
   getAvgMessagesInChats,
-  getCipChats,
+//   getCipChats,
   getDurationChats,
   getIdleChats,
   getTotalChats,
@@ -13,8 +13,8 @@ export const fetchData = (config: any) => {
   switch (config.metric) {
     case 'total':
       return fetchChartDataWithSubOptions(getTotalChats(), config, chatOptions[0].subOptions!);
-    case 'cip':
-      return fetchChartDataWithSubOptions(getCipChats(), config, chatOptions[1].subOptions!);
+//     case 'cip':
+//       return fetchChartDataWithSubOptions(getCipChats(), config, chatOptions[1].subOptions!);
     case 'avgConversationTime':
       return fetchChartData(getDurationChats(), config, chatOptions[2].labelKey);
     case 'avgWaitingTime':

--- a/GUI/src/pages/ChatsPage/options.tsx
+++ b/GUI/src/pages/ChatsPage/options.tsx
@@ -12,17 +12,17 @@ export const chatOptions: Option[] = [
     ],
     unit: t('units.chats') ?? 'chats',
   },
-  {
-    id: 'cip',
-    labelKey: 'chats.cip',
-    subOptions: [
-      { id: 'outside-working-hours', labelKey: 'chats.outsideWorkingHours', color: '#fdbf47' },
-      { id: 'long-waiting-time', labelKey: 'chats.longWaitingTime', color: '#ed7d32' },
-      { id: 'all-csas-away', labelKey: 'chats.allCsvAway', color: '#8ab4d5' },
-      { id: 'total', labelKey: 'chats.totalCount', color: '#008000' },
-    ],
-    unit: t('units.chats') ?? 'chats',
-  },
+//   {
+//     id: 'cip',
+//     labelKey: 'chats.cip',
+//     subOptions: [
+//       { id: 'outside-working-hours', labelKey: 'chats.outsideWorkingHours', color: '#fdbf47' },
+//       { id: 'long-waiting-time', labelKey: 'chats.longWaitingTime', color: '#ed7d32' },
+//       { id: 'all-csas-away', labelKey: 'chats.allCsvAway', color: '#8ab4d5' },
+//       { id: 'total', labelKey: 'chats.totalCount', color: '#008000' },
+//     ],
+//     unit: t('units.chats') ?? 'chats',
+//   },
   {
     id: 'avgConversationTime',
     labelKey: 'chats.avgConversationTime',


### PR DESCRIPTION
Part of the issue https://github.com/buerokratt/Buerokratt-Chatbot/issues/818 . Since the statistics were currently not working I commented out the part that was responsible for showing the "kontakti jätmised" in the chats sections of the analytics.