### PR TITLE
feat: Fix avg feedback query to get bureokratt messages instead of chatbot

### DIFF
--- a/DSL/Resql/feedback-avg-feedback-to-buerokratt-chats.sql
+++ b/DSL/Resql/feedback-avg-feedback-to-buerokratt-chats.sql
@@ -5,7 +5,7 @@ WHERE EXISTS
     (SELECT 1
      FROM message
      WHERE message.chat_base_id = chat.base_id
-       AND message.author_role = 'end-user'
+       AND message.author_role = 'buerokratt'
        AND message.event = 'CLIENT_LEFT_WITH_ACCEPTED')
 AND status = 'ENDED'
 AND created::date BETWEEN :start::date AND :end::date


### PR DESCRIPTION
Fix analytics module avg feedback sql query to get 'buerokratt' author-role messages instead of 'chatbot' author-role messages #291

Original PR:

- https://github.com/buerokratt/Analytics-Module/pull/312