### PR TITLE
Add period chat counts to chart legend (#323)

### DIFF
--- a/GUI/src/components/BarGraph/index.tsx
+++ b/GUI/src/components/BarGraph/index.tsx
@@ -1,8 +1,18 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { BarChart, CartesianGrid, YAxis, Tooltip, Legend, Bar, Label, XAxis } from 'recharts';
-import { chartDataKey, dateFormatter, formatDate, getColor, getKeys, getTicks, round } from '../../util/charts-utils';
+import {
+  chartDataKey,
+  dateFormatter,
+  formatDate,
+  getColor,
+  getKeys,
+  getPeriodTotalCounts,
+  getTicks,
+  round,
+} from '../../util/charts-utils';
 import { GroupByPeriod } from '../MetricAndPeriodOptions/types';
 import { useTranslation } from 'react-i18next';
+import { use } from 'i18next';
 
 type Props = {
   data: any;
@@ -14,6 +24,7 @@ type Props = {
 
 const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeriod }) => {
   const [width, setWidth] = useState<number | null>(null);
+  const [totalPeriodCounts, setTotalPeriodCounts] = useState<Record<string, number>>({});
   const ref = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
@@ -31,6 +42,18 @@ const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeri
     const millisecondInOneDay = 24 * 60 * 60 * 1000;
     minDate = minDate - millisecondInOneDay;
   }
+
+  useEffect(() => {
+    // todo does not update when changing period
+    console.log('hook', data.chartData);
+    const totals = getPeriodTotalCounts(data.chartData);
+    console.log('totals', totals);
+    setTotalPeriodCounts(totals);
+  }, [data.chartData]);
+
+  // console.log('data', data.chartData);
+  // console.log(unit);
+  // console.log('PERIOD COUNTS', getPeriodTotalCounts(data.chartData));
 
   const domain = [minDate, new Date(endDate).getTime()];
   const ticks = getTicks(startDate, endDate, new Date(startDate), new Date(endDate), 5);
@@ -84,7 +107,20 @@ const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeri
           }}
           cursor={false}
         />
-        <Legend wrapperStyle={{ position: 'relative', marginTop: '20px' }} />
+        <Legend
+          wrapperStyle={{ position: 'relative', marginTop: '20px' }}
+          formatter={(value) => {
+            // const totals = getPeriodTotalCounts(data.chartData);
+            console.log('totalPeriodCounts', totalPeriodCounts);
+            console.log('totalPeriodCounts[value]', totalPeriodCounts[value]);
+            // console.log('entry', entry);
+            // console.log('index', index);
+            return `${value}${totalPeriodCounts[value] ? ` (${totalPeriodCounts[value]})` : ''}`;
+
+            // return `${value}${Object.keys(totalPeriodCounts).includes(value) ? ` (${totalPeriodCounts[value]})` : ''}`;
+          }}
+          // accumulate="sum"
+        />
         {data?.chartData?.length > 0 &&
           getKeys(data.chartData).map((k, i) => {
             const isCount = k === t('chats.totalCount');

--- a/GUI/src/components/BarGraph/index.tsx
+++ b/GUI/src/components/BarGraph/index.tsx
@@ -1,18 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { BarChart, CartesianGrid, YAxis, Tooltip, Legend, Bar, Label, XAxis } from 'recharts';
-import {
-  chartDataKey,
-  dateFormatter,
-  formatDate,
-  getColor,
-  getKeys,
-  getPeriodTotalCounts,
-  getTicks,
-  round,
-} from '../../util/charts-utils';
+import { chartDataKey, dateFormatter, formatDate, getColor, getKeys, getTicks, round } from '../../util/charts-utils';
 import { GroupByPeriod } from '../MetricAndPeriodOptions/types';
 import { useTranslation } from 'react-i18next';
-import { use } from 'i18next';
 import { useTotalPeriodCounts } from '../../hooks/ useTotalPeriodCounts';
 
 type Props = {
@@ -99,17 +89,7 @@ const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeri
         />
         <Legend
           wrapperStyle={{ position: 'relative', marginTop: '20px' }}
-          formatter={(value) => {
-            // const totals = getPeriodTotalCounts(data.chartData);
-            // console.log('totalPeriodCounts', totalPeriodCounts);
-            // console.log('totalPeriodCounts[value]', totalPeriodCounts[value]);
-            // console.log('entry', entry);
-            // console.log('index', index);
-            return `${value}${totalPeriodCounts[value] ? ` (${totalPeriodCounts[value]})` : ''}`;
-
-            // return `${value}${Object.keys(totalPeriodCounts).includes(value) ? ` (${totalPeriodCounts[value]})` : ''}`;
-          }}
-          // accumulate="sum"
+          formatter={(value) => `${value}${totalPeriodCounts[value] ? ` (${totalPeriodCounts[value]})` : ''}`}
         />
         {data?.chartData?.length > 0 &&
           getKeys(data.chartData).map((k, i) => {

--- a/GUI/src/components/BarGraph/index.tsx
+++ b/GUI/src/components/BarGraph/index.tsx
@@ -13,6 +13,7 @@ import {
 import { GroupByPeriod } from '../MetricAndPeriodOptions/types';
 import { useTranslation } from 'react-i18next';
 import { use } from 'i18next';
+import { useTotalPeriodCounts } from '../../hooks/ useTotalPeriodCounts';
 
 type Props = {
   data: any;
@@ -24,7 +25,8 @@ type Props = {
 
 const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeriod }) => {
   const [width, setWidth] = useState<number | null>(null);
-  const [totalPeriodCounts, setTotalPeriodCounts] = useState<Record<string, number>>({});
+  const totalPeriodCounts = useTotalPeriodCounts(data.chartData, unit);
+
   const ref = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
@@ -42,12 +44,6 @@ const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeri
     const millisecondInOneDay = 24 * 60 * 60 * 1000;
     minDate = minDate - millisecondInOneDay;
   }
-
-  useEffect(() => {
-    if (unit !== t('units.chats')) return;
-
-    setTotalPeriodCounts(getPeriodTotalCounts(data.chartData));
-  }, [data.chartData]);
 
   const domain = [minDate, new Date(endDate).getTime()];
   const ticks = getTicks(startDate, endDate, new Date(startDate), new Date(endDate), 5);

--- a/GUI/src/components/BarGraph/index.tsx
+++ b/GUI/src/components/BarGraph/index.tsx
@@ -108,8 +108,8 @@ const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeri
           wrapperStyle={{ position: 'relative', marginTop: '20px' }}
           formatter={(value) => {
             // const totals = getPeriodTotalCounts(data.chartData);
-            console.log('totalPeriodCounts', totalPeriodCounts);
-            console.log('totalPeriodCounts[value]', totalPeriodCounts[value]);
+            // console.log('totalPeriodCounts', totalPeriodCounts);
+            // console.log('totalPeriodCounts[value]', totalPeriodCounts[value]);
             // console.log('entry', entry);
             // console.log('index', index);
             return `${value}${totalPeriodCounts[value] ? ` (${totalPeriodCounts[value]})` : ''}`;

--- a/GUI/src/components/BarGraph/index.tsx
+++ b/GUI/src/components/BarGraph/index.tsx
@@ -44,16 +44,13 @@ const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeri
   }
 
   useEffect(() => {
-    // todo does not update when changing period
-    console.log('hook', data.chartData);
+    console.log('unit', unit);
+    // todo use t
+    if (unit !== 'vestlused') return;
+
     const totals = getPeriodTotalCounts(data.chartData);
-    console.log('totals', totals);
     setTotalPeriodCounts(totals);
   }, [data.chartData]);
-
-  // console.log('data', data.chartData);
-  // console.log(unit);
-  // console.log('PERIOD COUNTS', getPeriodTotalCounts(data.chartData));
 
   const domain = [minDate, new Date(endDate).getTime()];
   const ticks = getTicks(startDate, endDate, new Date(startDate), new Date(endDate), 5);

--- a/GUI/src/components/BarGraph/index.tsx
+++ b/GUI/src/components/BarGraph/index.tsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { BarChart, CartesianGrid, YAxis, Tooltip, Legend, Bar, Label, XAxis } from 'recharts';
-import { chartDataKey, dateFormatter, formatDate, getColor, getKeys, getTicks, round } from '../../util/charts-utils';
+import {
+  chartDataKey,
+  dateFormatter,
+  formatDate,
+  formatTotalPeriodCount,
+  getColor,
+  getKeys,
+  getTicks,
+  round,
+} from '../../util/charts-utils';
 import { GroupByPeriod } from '../MetricAndPeriodOptions/types';
 import { useTranslation } from 'react-i18next';
 import { useTotalPeriodCounts } from '../../hooks/ useTotalPeriodCounts';
@@ -89,7 +98,7 @@ const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeri
         />
         <Legend
           wrapperStyle={{ position: 'relative', marginTop: '20px' }}
-          formatter={(value) => `${value}${totalPeriodCounts[value] ? ` (${totalPeriodCounts[value]})` : ''}`}
+          formatter={(value) => `${value}${formatTotalPeriodCount(totalPeriodCounts, value)}`}
         />
         {data?.chartData?.length > 0 &&
           getKeys(data.chartData).map((k, i) => {

--- a/GUI/src/components/BarGraph/index.tsx
+++ b/GUI/src/components/BarGraph/index.tsx
@@ -44,12 +44,9 @@ const BarGraph: React.FC<Props> = ({ startDate, endDate, data, unit, groupByPeri
   }
 
   useEffect(() => {
-    console.log('unit', unit);
-    // todo use t
-    if (unit !== 'vestlused') return;
+    if (unit !== t('units.chats')) return;
 
-    const totals = getPeriodTotalCounts(data.chartData);
-    setTotalPeriodCounts(totals);
+    setTotalPeriodCounts(getPeriodTotalCounts(data.chartData));
   }, [data.chartData]);
 
   const domain = [minDate, new Date(endDate).getTime()];

--- a/GUI/src/components/LineGraph/index.tsx
+++ b/GUI/src/components/LineGraph/index.tsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { LineChart, XAxis, Line, CartesianGrid, YAxis, Tooltip, Legend, Label } from 'recharts';
-import { chartDataKey, dateFormatter, formatDate, getColor, getKeys, getTicks, round } from '../../util/charts-utils';
+import {
+  chartDataKey,
+  dateFormatter,
+  formatDate,
+  formatTotalPeriodCount,
+  getColor,
+  getKeys,
+  getTicks,
+  round,
+} from '../../util/charts-utils';
 import { useTotalPeriodCounts } from '../../hooks/ useTotalPeriodCounts';
 
 type Props = {
@@ -76,9 +85,8 @@ const LineGraph = ({ data, startDate, endDate, unit }: Props) => {
           />
         </YAxis>
         <Legend
-          // todo helper fn
           wrapperStyle={{ position: 'relative', marginTop: '20px' }}
-          formatter={(value) => `${value}${totalPeriodCounts[value] ? ` (${totalPeriodCounts[value]})` : ''}`}
+          formatter={(value) => `${value}${formatTotalPeriodCount(totalPeriodCounts, value)}`}
         />
         <CartesianGrid stroke="#f5f5f5" />
         {data?.chartData?.length > 0 &&

--- a/GUI/src/components/LineGraph/index.tsx
+++ b/GUI/src/components/LineGraph/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { LineChart, XAxis, Line, CartesianGrid, YAxis, Tooltip, Legend, Label } from 'recharts';
 import { chartDataKey, dateFormatter, formatDate, getColor, getKeys, getTicks, round } from '../../util/charts-utils';
+import { useTotalPeriodCounts } from '../../hooks/ useTotalPeriodCounts';
 
 type Props = {
   data: any;
@@ -12,6 +13,7 @@ type Props = {
 const LineGraph = ({ data, startDate, endDate, unit }: Props) => {
   const [width, setWidth] = useState<number | null>(null);
   const ref = useRef<HTMLDivElement>(null);
+  const totalPeriodCounts = useTotalPeriodCounts(data.chartData, unit);
 
   useEffect(() => {
     const handleResize = () => {
@@ -73,7 +75,11 @@ const LineGraph = ({ data, startDate, endDate, unit }: Props) => {
             value={unit}
           />
         </YAxis>
-        <Legend wrapperStyle={{ position: 'relative', marginTop: '20px' }} />
+        <Legend
+          // todo helper fn
+          wrapperStyle={{ position: 'relative', marginTop: '20px' }}
+          formatter={(value) => `${value}${totalPeriodCounts[value] ? ` (${totalPeriodCounts[value]})` : ''}`}
+        />
         <CartesianGrid stroke="#f5f5f5" />
         {data?.chartData?.length > 0 &&
           getKeys(data.chartData).map((k, i) => {

--- a/GUI/src/components/MetricsCharts/index.tsx
+++ b/GUI/src/components/MetricsCharts/index.tsx
@@ -43,7 +43,12 @@ const MetricsCharts = ({ title, data, startDate, endDate, unit, groupByPeriod }:
 
   const buildChart = () => {
     if (selectedChart === 'pieChart') {
-      return <PieGraph data={data} />;
+      return (
+        <PieGraph
+          data={data}
+          unit={unit}
+        />
+      );
     } else if (selectedChart === 'lineChart') {
       return (
         <LineGraph

--- a/GUI/src/components/PieGraph/PieCharLegends.tsx
+++ b/GUI/src/components/PieGraph/PieCharLegends.tsx
@@ -9,6 +9,9 @@ type Props = {
 };
 
 const PieCharLegends = ({ data, percentages }: Props) => {
+  console.log('percentages', percentages);
+  console.log('data', data);
+
   return (
     <Track
       direction="vertical"
@@ -17,22 +20,19 @@ const PieCharLegends = ({ data, percentages }: Props) => {
       isFlex
       isMultiline
     >
-      {
-        percentages?.map((e: any) => {
-          const color = getColor(data, e.name);
+      {percentages?.map((e: any) => {
+        const color = getColor(data, e.name);
 
-          return (
-            <Track key={`track-${e.name}`}>
-              <div
-                className="legend_circle"
-                style={{ backgroundColor: color }}
-              />
-              <label style={{ color, maxLines: 1 }}>
-                {`${e.name}: ${e.value} %`}
-              </label>
-            </Track>
-          )})
-      }
+        return (
+          <Track key={`track-${e.name}`}>
+            <div
+              className="legend_circle"
+              style={{ backgroundColor: color }}
+            />
+            <label style={{ color, maxLines: 1 }}>{`${e.name}: ${e.value} %`}</label>
+          </Track>
+        );
+      })}
     </Track>
   );
 };

--- a/GUI/src/components/PieGraph/PieCharLegends.tsx
+++ b/GUI/src/components/PieGraph/PieCharLegends.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
-import { getColor } from '../../util/charts-utils';
+import { formatTotalPeriodCount, getColor } from '../../util/charts-utils';
 import Track from '../Track';
 import './PieGraph.scss';
+import { useTotalPeriodCounts } from '../../hooks/ useTotalPeriodCounts';
 
 type Props = {
   data: any;
   percentages: any;
+  unit?: string;
 };
 
-const PieCharLegends = ({ data, percentages }: Props) => {
-  console.log('percentages', percentages);
-  console.log('data', data);
+const PieCharLegends = ({ data, percentages, unit }: Props) => {
+  const totalPeriodCounts = useTotalPeriodCounts(data.chartData, unit);
 
   return (
     <Track
@@ -29,7 +30,9 @@ const PieCharLegends = ({ data, percentages }: Props) => {
               className="legend_circle"
               style={{ backgroundColor: color }}
             />
-            <label style={{ color, maxLines: 1 }}>{`${e.name}: ${e.value} %`}</label>
+            <label style={{ color, maxLines: 1 }}>
+              {`${e.name}: ${e.value} %${formatTotalPeriodCount(totalPeriodCounts, e.name)}`}
+            </label>
           </Track>
         );
       })}

--- a/GUI/src/components/PieGraph/index.tsx
+++ b/GUI/src/components/PieGraph/index.tsx
@@ -11,15 +11,16 @@ import './PieGraph.scss';
 
 type Props = {
   data: any;
+  unit?: string;
 };
 
-const PieGraph = ({ data }: Props) => {
+const PieGraph = ({ data, unit }: Props) => {
   const [width, setWidth] = useState<number | null>(null);
   const ref = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
   const percentages = useMemo(() => calculatePercentagesFromResponse(data?.chartData ?? []), [data?.chartData]);
-  
+
   useEffect(() => {
     const handleResize = () => {
       setWidth(ref.current?.clientWidth ?? 0);
@@ -38,28 +39,32 @@ const PieGraph = ({ data }: Props) => {
           data={data.chartData}
           margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
         >
-            <Pie
-              data={percentages}
-              cx="50%"
-              cy="50%"
-              outerRadius='100%'
-              fill="#8884d8"
-              dataKey="value"
-              nameKey="name"
-            >
-              {percentages.map((e: any) =>
-                <Cell
-                  key={`cell-${e['name']}`}
-                  type="monotone"
-                  stroke={getColor(data, e['name'])}
-                  fill={getColor(data, e['name'])}
-                />
-              )}
-            </Pie>
+          <Pie
+            data={percentages}
+            cx="50%"
+            cy="50%"
+            outerRadius="100%"
+            fill="#8884d8"
+            dataKey="value"
+            nameKey="name"
+          >
+            {percentages.map((e: any) => (
+              <Cell
+                key={`cell-${e['name']}`}
+                type="monotone"
+                stroke={getColor(data, e['name'])}
+                fill={getColor(data, e['name'])}
+              />
+            ))}
+          </Pie>
           <Tooltip content={data?.percentages ? <PercentageToolTip /> : <ChartToolTip />} />
         </PieChart>
         {percentages.length === 0 && <span>{t('chart.noDataToPlot')}</span>}
-        <PieCharLegends data={data} percentages={percentages} />
+        <PieCharLegends
+          data={data}
+          percentages={percentages}
+          unit={unit}
+        />
       </Track>
     </div>
   );

--- a/GUI/src/hooks/ useTotalPeriodCounts.ts
+++ b/GUI/src/hooks/ useTotalPeriodCounts.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getPeriodTotalCounts } from '../util/charts-utils';
+
+export const useTotalPeriodCounts = (chartData: any[], unit: string | undefined) => {
+  const [totalPeriodCounts, setTotalPeriodCounts] = useState<Record<string, number>>({});
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    console.log('HOOK unit', unit);
+    if (unit !== t('units.chats')) return;
+
+    setTotalPeriodCounts(getPeriodTotalCounts(chartData));
+  }, [chartData, unit, t]);
+
+  return totalPeriodCounts;
+};

--- a/GUI/src/hooks/ useTotalPeriodCounts.ts
+++ b/GUI/src/hooks/ useTotalPeriodCounts.ts
@@ -1,17 +1,27 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getPeriodTotalCounts } from '../util/charts-utils';
 
-export const useTotalPeriodCounts = (chartData: any[], unit: string | undefined) => {
+export const useTotalPeriodCounts = (chartData: Record<string, number>[] | undefined, unit: string | undefined) => {
   const [totalPeriodCounts, setTotalPeriodCounts] = useState<Record<string, number>>({});
   const { t } = useTranslation();
 
   useEffect(() => {
-    console.log('HOOK unit', unit);
-    if (unit !== t('units.chats')) return;
+    if (!chartData?.length || unit !== t('units.chats')) return;
 
     setTotalPeriodCounts(getPeriodTotalCounts(chartData));
   }, [chartData, unit, t]);
 
   return totalPeriodCounts;
+};
+
+const getPeriodTotalCounts = (chartData: Record<string, number>[]) => {
+  const totals: Record<string, number> = {};
+
+  chartData.forEach((entry) => {
+    Object.entries(entry).forEach(([key, value]) => {
+      if (key !== 'dateTime') totals[key] = (totals[key] ?? 0) + value;
+    });
+  });
+
+  return totals;
 };

--- a/GUI/src/util/charts-utils.tsx
+++ b/GUI/src/util/charts-utils.tsx
@@ -52,23 +52,3 @@ export const chartDataKey = 'dateTime';
 export const round = (value: any) => Math.round(Number(value) * 100) / 100;
 
 export const getKeys = (data: any[]) => Array.from(new Set(data.flatMap((obj: any) => Object.keys(obj))));
-
-export const getPeriodTotalCounts = (chartData: Record<string, number>[]) => {
-  const totals: Record<string, number> = {};
-  console.log('chartData in COUNT', chartData);
-
-  // todo handle this and empty array
-  if (!chartData) return {};
-
-  chartData.forEach((entry) => {
-    Object.entries(entry).forEach(([key, value]) => {
-      if (key !== 'dateTime') {
-        totals[key] = (totals[key] ?? 0) + value;
-      }
-    });
-  });
-
-  console.log('totals', totals);
-
-  return totals;
-};

--- a/GUI/src/util/charts-utils.tsx
+++ b/GUI/src/util/charts-utils.tsx
@@ -52,3 +52,23 @@ export const chartDataKey = 'dateTime';
 export const round = (value: any) => Math.round(Number(value) * 100) / 100;
 
 export const getKeys = (data: any[]) => Array.from(new Set(data.flatMap((obj: any) => Object.keys(obj))));
+
+export const getPeriodTotalCounts = (chartData: Record<string, number>[]) => {
+  const totals: Record<string, number> = {};
+  console.log('chartData in COUNT', chartData);
+
+  // todo handle this and empty array
+  if (!chartData) return {};
+
+  chartData.forEach((entry) => {
+    Object.entries(entry).forEach(([key, value]) => {
+      if (key !== 'dateTime') {
+        totals[key] = (totals[key] ?? 0) + value;
+      }
+    });
+  });
+
+  console.log('totals', totals);
+
+  return totals;
+};

--- a/GUI/src/util/charts-utils.tsx
+++ b/GUI/src/util/charts-utils.tsx
@@ -52,3 +52,6 @@ export const chartDataKey = 'dateTime';
 export const round = (value: any) => Math.round(Number(value) * 100) / 100;
 
 export const getKeys = (data: any[]) => Array.from(new Set(data.flatMap((obj: any) => Object.keys(obj))));
+
+export const formatTotalPeriodCount = (totalPeriodCounts: Record<string, number>, metric: string) =>
+  `${totalPeriodCounts[metric] ? ` (${totalPeriodCounts[metric]})` : ''}`;


### PR DESCRIPTION
Related tasks:

- https://github.com/buerokratt/Analytics-Module/issues/330
- https://github.com/buerokratt/Analytics-Module/issues/328
- https://github.com/buerokratt/Analytics-Module/issues/329

Notes:

- Was not really sure about this but implemented in FE — and not SQL — since we already seem to do some calculations/data processing in FE, like `getTicks` [here](https://github.com/buerokratt/Analytics-Module/blob/25b5d6b03794c276ef0e87776b0c477876f0e060/GUI/src/util/charts-utils.tsx#L8). 
- This adds chat counts to _every_ chart legend in the module, not only those on chat page. We had a call with @RiinaLi who confirmed that this is even better — and this is actually easier to do in code.
- Could probably have better types than `Record` in this PR but since we have lots of `any` types, refactoring this is huge and dangerous at this point.