### PR TITLE
Hot-Fix: Bulletpoints in LLM response don't allways start with 1

### DIFF
--- a/GUI/src/components/ChatEvent/Markdownify.tsx
+++ b/GUI/src/components/ChatEvent/Markdownify.tsx
@@ -40,7 +40,7 @@ const Markdownify: React.FC<MarkdownifyProps> = ({ message }) => (
         disableParsingRawHTML: true,
       }}
     >
-      {message?.replace(/&#x([0-9A-Fa-f]+);/g, (_, hex) => { return String.fromCharCode(parseInt(hex, 16)); }) ?? ""}
+      {message?.replace(/&#x([0-9A-Fa-f]+);/g, (_, hex) => { return String.fromCharCode(parseInt(hex, 16)); }).replace(/(?<=\n)\d+\.\s/g, "\n\n$&") ?? ""}
     </Markdown>
   </div>
 );


### PR DESCRIPTION
Related Task:

- https://github.com/buerokratt/Buerokratt-Chatbot/issues/1204