### PR TITLE
Remove broken highlighting from pie chart

### DIFF
--- a/GUI/src/components/PieGraph/PieGraph.scss
+++ b/GUI/src/components/PieGraph/PieGraph.scss
@@ -4,3 +4,7 @@
     border-radius: 100%;
     margin-right: 10px;
 }
+
+.recharts-wrapper * { 
+    outline: none; 
+}


### PR DESCRIPTION
Remove broken highlighting from pie chart.
This PR is related to issue https://github.com/buerokratt/Analytics-Module/issues/410.